### PR TITLE
rethinkdb 2.3.6 version updated

### DIFF
--- a/beginners/rethinkdb/Dockerfile
+++ b/beginners/rethinkdb/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Daniel Alan Miller dalanmiller@rethinkdb.com
 
 RUN apt-key adv --keyserver pgp.mit.edu --recv-keys1614552E5765227AEC39EFCFA7E00EF33A8F2399 RUN echo "deb http://download.rethinkdb.com/apt jessie main" > /etc/apt/sources.list.d/rethinkdb.list
 
-ENV RETHINKDBPACKAGEVERSION 2.0.4~0jessie
+ENV RETHINKDBPACKAGEVERSION 2.3.6~0jessie
 
 RUN apt-get update && apt-get install -y rethinkdb=$RETHINKDBPACKAGEVERSION && rm -rf /var/lib/apt/lists/*
 

--- a/beginners/rethinkdb/README.md
+++ b/beginners/rethinkdb/README.md
@@ -6,7 +6,7 @@ RethinkDB is a free and open-source, distributed document-oriented database orig
 ## RethinkDB Dockerfile
 
 
-This repository contains **Dockerfile** of [RethinkDB](http://www.rethinkdb.com/) for [Docker](https://www.docker.com/)'s [automated build](https://registry.hub.docker.com/u/dockerfile/rethinkdb/) published to the public [Docker Hub Registry](https://registry.hub.docker.com/).
+This repository contains **Dockerfile** of [RethinkDB](http://www.rethinkdb.com/) for [Docker](https://www.docker.com/)'s [automated build](https://hub.docker.com/_/rethinkdb/) published to the public [Docker Hub Registry](https://registry.hub.docker.com/).
 
 
 ### Installation


### PR DESCRIPTION
Rethinkdb version updated in a Dockerfile and corrected a broken link.
Thank you.