### PR TITLE
Fixing issue #311

### DIFF
--- a/kubernetes/workshop/Deployment101/nginx-dep.yaml
+++ b/kubernetes/workshop/Deployment101/nginx-dep.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: nginx-deployment


### PR DESCRIPTION
[DockerLab] no matches for kind "Deployment" in version "apps/v1beta2" #311
apps/v1beta2 is deprecated since k8s v1.16