### PR TITLE
Adding macOS docker daemon configuration location

### DIFF
--- a/beginners/components/daemon/README.md
+++ b/beginners/components/daemon/README.md
@@ -52,7 +52,7 @@ There are two ways to configure the Docker daemon:
 
 You can use both of these options together as long as you don’t specify the same option both as a flag and in the JSON file. If that happens, the Docker daemon won’t start and prints an error message.
 
-To configure the Docker daemon using a JSON file, create a file at /etc/docker/daemon.json on Linux systems, or C:\ProgramData\docker\config\daemon.json on Windows. On MacOS go to the whale in the taskbar > Preferences > Daemon > Advanced.
+To configure the Docker daemon using a JSON file, create a file at /etc/docker/daemon.json on Linux systems, or C:\ProgramData\docker\config\daemon.json on Windows. On MacOS go to the whale in the taskbar > Preferences > Daemon > Advanced, or locate ~/.docker/daemon.json.
 
 Here’s what the configuration file looks like:
 


### PR DESCRIPTION
If you break the config file, you can't edit it from the Preferences because the deamon fails to launch. Users need to know the location of this file to manually remove/edit.