### PR TITLE
Updating line breaks for multiple RUN instructions

### DIFF
--- a/beginners/dockerfile/Lab#7:RUN_instruction.md
+++ b/beginners/dockerfile/Lab#7:RUN_instruction.md
@@ -74,8 +74,8 @@ Its 8.42MB
 ```
 FROM alpine:3.9.3
 LABEL maintainer="Collabnix"
-RUN apk add --update \ &&
-	apk add curl \ &&  
+RUN apk add --update && \
+	apk add curl  && \  
 	rm -rf /var/cache/apk/
 ```
 #### Building Docker image


### PR DESCRIPTION
Ran with existing command and it is failing with below output.

[node3] (local) root@192.168.0.11 ~
$ cat Dockerfile
FROM alpine:3.9.3
LABEL maintainer="Collabnix"
RUN apk add --update \ &&
        apk add curl \ &&  
        rm -rf /var/cache/apk/
[node3] (local) root@192.168.0.11 ~
$ docker image build -t run:v2 .
Sending build context to Docker daemon  46.79MB
Error response from daemon: Dockerfile parse error line 4: unknown instruction: APK

Updated the command and the RUN command is successful.
[node3] (local) root@192.168.0.11 ~
$ cat Dockerfile
FROM alpine:3.9.3
LABEL maintainer="Collabnix"
RUN apk add --update && \
        apk add curl && \
        rm -rf /var/cache/apk/
[node3] (local) root@192.168.0.11 ~
$ docker image build -t run:v2 .
Sending build context to Docker daemon  46.79MB
Step 1/3 : FROM alpine:3.9.3
3.9.3: Pulling from library/alpine
bdf0201b3a05: Pull complete 
Digest: sha256:28ef97b8686a0b5399129e9b763d5b7e5ff03576aa5580d6f4182a49c5fe1913
Status: Downloaded newer image for alpine:3.9.3
 ---> cdf98d1859c1
Step 2/3 : LABEL maintainer="Collabnix"
 ---> Running in 4ac5e3efa99c
Removing intermediate container 4ac5e3efa99c
 ---> ea6cdf1ca5ae
Step 3/3 : RUN apk add --update &&      apk add curl &&         rm -rf /var/cache/apk/
 ---> Running in ea07ab101bdf
fetch http://dl-cdn.alpinelinux.org/alpine/v3.9/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.9/community/x86_64/APKINDEX.tar.gz
OK: 6 MiB in 14 packages
(1/5) Installing ca-certificates (20191127-r2)
(2/5) Installing nghttp2-libs (1.35.1-r2)
(3/5) Installing libssh2 (1.9.0-r1)
(4/5) Installing libcurl (7.64.0-r3)
(5/5) Installing curl (7.64.0-r3)
Executing busybox-1.29.3-r10.trigger
Executing ca-certificates-20191127-r2.trigger
OK: 7 MiB in 19 packages
Removing intermediate container ea07ab101bdf
 ---> 5512699b892d
Successfully built 5512699b892d
Successfully tagged run:v2
[node3] (local) root@192.168.0.11 ~