### PR TITLE
Update the image inspect format section

### DIFF
--- a/beginners/dockerfile/Lab#11:EXPOSE_instruction.md
+++ b/beginners/dockerfile/Lab#11:EXPOSE_instruction.md
@@ -55,7 +55,7 @@ $  docker container run --rm -d --name expose-inst expose:v1
 
 ### Inspecting the EXPOSE port in the image
 ```
-$ docker image inspect --format {{.ContainerConfig.ExposedPorts}} expose:v1
+$ docker image inspect --format={{.ContainerConfig.ExposedPorts}} expose:v1
 ```
 
 ### Publish all exposed ports


### PR DESCRIPTION
Currently in page https://dockerlabs.collabnix.com/beginners/dockerfile/Lab%2311:EXPOSE_instruction.html

"docker image inspect --format {{.ContainerConfig.ExposedPorts}} expose:v1" is seen as "docker image inspect --format expose:v1" without ContainerConfig.ExposedPorts 
tried it on firefox and chrome and below is the error from the command.

[node3] (local) root@192.168.0.31 ~
$ docker image inspect --format expose:v1
"docker image inspect" requires at least 1 argument.
See 'docker image inspect --help'.

Usage:  docker image inspect [OPTIONS] IMAGE [IMAGE...]

Display detailed information on one or more images

[node3] (local) root@192.168.0.31 ~
$ docker image inspect --format={{.ContainerConfig.ExposedPorts}} expose:v1
map[80/tcp:{} 80/udp:{}]

Note:
Below command also works but in the given link it is not showing the ContainerConfig
[node3] (local) root@192.168.0.31 ~
$ docker image inspect --format {{.ContainerConfig.ExposedPorts}} expose:v1
map[80/tcp:{} 80/udp:{}]