### PR TITLE
Fix Link of Pre-Requisites

### DIFF
--- a/workshop/docker/README.md
+++ b/workshop/docker/README.md
@@ -4,7 +4,7 @@
 
 ### Pre-requisite:
 
-- [Creating Your DockerHub Account](https://github.com/collabnix/dockerlabs/blob/master/workshop/docker/dockerhub.md)
+- [Creating Your DockerHub Account](https://dockerlabs.collabnix.com/workshop/docker/dockerhub)
 
 ### Getting Started with Docker Image
 
@@ -83,5 +83,3 @@
    - [Lab #8: Configure NAT for external connectivity](http://dockerlabs.collabnix.com/networking/A2-bridge-networking.html#step-4-configure-nat-for-external-connectivity)
  
  
-
-

--- a/workshop/docker/dockerhub.md
+++ b/workshop/docker/dockerhub.md
@@ -2,21 +2,19 @@
 
 ### Open [https://hub.docker.com](https://dockr.ly/3Q0iiPA) and click on "Sign Up" for DockerHub
 
-![My image](https://github.com/collabnix/dockerlabs/blob/master/workshop/docker/dockerhub1.png)
+![My image](https://raw.githubusercontent.com/collabnix/dockerlabs/master/workshop/docker/dockerhub1.png)
 
 ### Enter your username as DockerID and provide your email address( I would suggest you to provide your Gmail ID)
 
-![My image](https://github.com/collabnix/dockerlabs/blob/master/workshop/docker/dockerhub2.png)
+![My image](https://raw.githubusercontent.com/collabnix/dockerlabs/master/workshop/docker/dockerhub2.png)
 
 ## Example
 
 I have added ajeetraina as my userID as shown below. Please note that we will require this userID at the later point of time during the workshop. Hence, do keep it handy.
 
-![My image](https://github.com/collabnix/dockerlabs/blob/master/workshop/docker/dockerhub3.png)
+![My image](https://raw.githubusercontent.com/collabnix/dockerlabs/master/workshop/docker/dockerhub3.png)
 
 ### That's it. Head over to your Email account to validate this account.
 
 
-![My image](https://github.com/collabnix/dockerlabs/blob/master/workshop/docker/dockerhub4.png)
-
-
+![My image](https://raw.githubusercontent.com/collabnix/dockerlabs/master/workshop/docker/dockerhub4.png)


### PR DESCRIPTION
Currently the link redirects to the GitHub markdown file. The pictures on the site it would link to are currently broken.

This fixes the pictures to be displayed on the site and the properly link to it like all other steps. With this change the links will be consistently keep you on the dockerlabs.collabnix.com website.