### PR TITLE
Update docker tag in labs for kubernetes nginx-dep.yaml

### DIFF
--- a/kubernetes/workshop/Deployment101/nginx-dep.yaml
+++ b/kubernetes/workshop/Deployment101/nginx-dep.yaml
@@ -14,6 +14,6 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: nginx:1.7.9
+        image: nginx:stable-perl
         ports:
         - containerPort: 80


### PR DESCRIPTION
1.7.9 It is an incorrect tag, for practical purposes I propose a change with 'stable-perl'