### PR TITLE
Fix broken Star History chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 If this repo helped you in your Docker journey, please star it! ⭐
 
-[![Star History Chart](https://api.star-history.com/svg?repos=collabnix/dockerlabs&type=Date)](https://star-history.com/#collabnix/dockerlabs&Date)
+[![Star History Chart](https://api.star-history.dera.page/svg?repos=collabnix/dockerlabs&type=Date)](https://star-history.dera.page/#collabnix/dockerlabs&Date)
 
 
 # 📝 Join our Community


### PR DESCRIPTION
The Star History chart shown on the README has been broken for a while now, since the upstream provider stopped working due to GitHub stargazer API restrictions.

This PR points the chart to an alternative service that uses a different data source which requires no API token, so the chart renders correctly again without any other changes to the project.